### PR TITLE
Add support for add HTTPHeader from URLSession

### DIFF
--- a/Sources/URLRouting/Client/Client.swift
+++ b/Sources/URLRouting/Client/Client.swift
@@ -63,7 +63,7 @@ extension URLRoutingClient {
   public static func live<R: ParserPrinter>(router: R, session: URLSession = .shared) -> Self
   where R.Input == URLRequestData, R.Output == Route {
     Self { route in
-      let request = try router.request(for: route)
+      let request = try router.request(for: route, session: session)
 
       #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {

--- a/Sources/URLRouting/Parsing/ParserPrinter.swift
+++ b/Sources/URLRouting/Parsing/ParserPrinter.swift
@@ -34,7 +34,7 @@ extension ParserPrinter where Input == URLRequestData {
     else { throw RoutingError() }
     session.configuration.httpAdditionalHeaders?.forEach({ header in
       if let key = header.key as? String {
-        request.addValue(key, forHTTPHeaderField: header.value as? String ?? "")
+        request.setValue(key, forHTTPHeaderField: header.value as? String ?? "")
       }
     })
     return request


### PR DESCRIPTION
The goal of this PR is to fix #4.

```swift
    let configuration: URLSessionConfiguration = .default
    configuration.httpAdditionalHeaders = [
      "Authorization": "supersecrettoken",
      "Accept" : "application/json"
    ]
    let session = URLSession(configuration: configuration)
    let api = URLRoutingClient<ApiRoute>.live(router: apiRouter.baseURL("http://127.0.0.1"), session: session)
    let output = try await api.request(.user(.fetch), as: UserResponse.self)
```