### PR TITLE
JSONDecoder at Client level

### DIFF
--- a/Tests/URLRoutingTests/URLRoutingClientTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingClientTests.swift
@@ -1,0 +1,58 @@
+import Parsing
+import URLRouting
+import XCTest
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+class URLRoutingClientTests: XCTestCase {
+  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  func testJSONDecoder_noDecoder() async throws {
+    struct Response: Equatable, Decodable {
+      let decodableValue: String
+    }
+    enum AppRoute {
+      case test
+    }
+    let sut = URLRoutingClient<AppRoute>(request: { _ in
+      ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
+    })
+    let response = try await sut.request(.test, as: Response.self)
+    XCTAssertEqual(response.value, .init(decodableValue: "result"))
+  }
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  func testJSONDecoder_customDecoder() async throws {
+    struct Response: Equatable, Decodable {
+      let decodableValue: String
+    }
+    enum AppRoute {
+      case test
+    }
+    let customDecoder = JSONDecoder()
+    customDecoder.keyDecodingStrategy = .convertFromSnakeCase
+    let sut = URLRoutingClient<AppRoute>(request: { _ in
+      ("{\"decodable_value\":\"result\"}".data(using: .utf8)!, URLResponse())
+    }, decoder: customDecoder)
+    let response = try await sut.request(.test, as: Response.self)
+    XCTAssertEqual(response.value, .init(decodableValue: "result"))
+  }
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  func testJSONDecoder_customDecoderForRequest() async throws {
+    struct Response: Equatable, Decodable {
+      let decodableValue: String
+    }
+    enum AppRoute {
+      case test
+    }
+    let customDecoder = JSONDecoder()
+    customDecoder.keyDecodingStrategy = .convertFromSnakeCase
+    let sut = URLRoutingClient<AppRoute>(request: { _ in
+      ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
+    }, decoder: customDecoder)
+    let response = try await sut.request(.test, as: Response.self, decoder: .init())
+    XCTAssertEqual(response.value, .init(decodableValue: "result"))
+  }
+  #endif
+}


### PR DESCRIPTION
In most of APIs, decoding mechanism is the same for all requests for a given client.

So, this PR introduces a `JSONDecoder` at the url-routing client level, without loosing the ability to specify a custom Decoder for each request if needed.

The client declaration is more clear for decoding :
```swift
let apiClient = URLRoutingClient.live(
  router: router.baseURL("https://127.0.0.1:8080"),
  decoder: customDecoder
)
```
And you don't have to store neither specify your custom Decoder at each request call.