### PR TITLE
Add URL Scheme parser and test

### DIFF
--- a/Sources/URLRouting/Scheme.swift
+++ b/Sources/URLRouting/Scheme.swift
@@ -1,0 +1,45 @@
+/// Parses a request's scheme.
+///
+/// Used to require a particular scheme at a particular endpoint.
+///
+/// ```swift
+/// Route(.case(SiteRoute.custom)) {
+///   Scheme("custom")  // Only route custom:// requests
+///   ...
+/// }
+/// ```
+public struct Scheme: ParserPrinter {
+  @usableFromInline
+  let name: String
+
+  /// A parser of the `http` scheme.
+  public static let http = Self("http")
+
+  /// A parser of the `https` scheme.
+  public static let https = Self("https")
+
+  /// A parser of custom schemes.
+  public static func custom(_ scheme: String) -> Self {
+    Self(scheme)
+  }
+
+  /// Initializes a scheme parser with a scheme name.
+  ///
+  /// - Parameter name: A method name.
+  @inlinable
+  public init(_ name: String) {
+    self.name = name
+  }
+
+  @inlinable
+  public func parse(_ input: inout URLRequestData) throws {
+    guard let scheme = input.scheme else { throw RoutingError() }
+    try self.name.parse(scheme)
+    input.scheme = nil
+  }
+
+  @inlinable
+  public func print(_ output: (), into input: inout URLRequestData) {
+    input.scheme = self.name
+  }
+}

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -12,6 +12,11 @@ class URLRoutingTests: XCTestCase {
     XCTAssertEqual(try Method.post.print(), URLRequestData(method: "POST"))
   }
 
+  func testScheme() {
+    XCTAssertNoThrow(try Scheme.http.parse(URLRequestData(scheme: "http")))
+    XCTAssertEqual(try Scheme.http.print(), URLRequestData(scheme: "http"))
+  }
+
   func testPath() {
     XCTAssertEqual(123, try Path { Int.parser() }.parse(URLRequestData(path: "/123")))
     XCTAssertThrowsError(try Path { Int.parser() }.parse(URLRequestData(path: "/123-foo"))) {


### PR DESCRIPTION
## 💬 Summary of Changes

- Implements a scheme parser to support routing older style custom schemes on iOS.

## ✅ Checklist

- [x] 🧐 Performed a self-review of the changes.
- [x] ✅ Added tests to cover changes.
- [x] 🏎 Ran Unit Tests before opening PR.
