### PR TITLE
URLRoutingClient updates

### DIFF
--- a/Sources/URLRouting/Client/Client.swift
+++ b/Sources/URLRouting/Client/Client.swift
@@ -6,13 +6,13 @@ import XCTestDynamicOverlay
   import FoundationNetworking
 #endif
 
-/// A type that can make requests to a server, download the response, and decode the response
-/// into a model.
+/// A type that can make requests to a server, download the response, and decode the response into a
+/// model.
 ///
 /// You do not typically construct this type directly from its initializer, and instead use the
-/// ``live(router:session:)`` static method for creating an API client from a parser-printer, or
-/// use the ``failing`` static variable for creating an API client that throws an error when a
-/// request is made and then use ``override(_:with:)-1ot4o`` to override certain routes with mocked
+/// ``live(router:session:)`` static method for creating an API client from a parser-printer, or use
+/// the ``failing`` static variable for creating an API client that throws an error when a request
+/// is made and then use ``override(_:with:)-1ot4o`` to override certain routes with mocked
 /// responses.
 public struct URLRoutingClient<Route> {
   var request: (Route) async throws -> (Data, URLResponse)
@@ -34,8 +34,8 @@ public struct URLRoutingClient<Route> {
   ///   - decoder: A JSON decoder.
   /// - Returns: The decoded value.
   @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-  public func request<Value: Decodable>(
-    _ route: Route,
+  public func decodedResponse<Value: Decodable>(
+    for route: Route,
     as type: Value.Type = Value.self,
     decoder: JSONDecoder? = nil
   ) async throws -> (value: Value, response: URLResponse) {

--- a/Sources/URLRouting/Client/Client.swift
+++ b/Sources/URLRouting/Client/Client.swift
@@ -28,6 +28,15 @@ public struct URLRoutingClient<Route> {
 
   /// Makes a request to a route.
   ///
+  /// - Parameter route: The route to request.
+  /// - Returns: The data and response.
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  public func data(for route: Route) async throws -> (value: Data, response: URLResponse) {
+    try await self.request(route)
+  }
+
+  /// Makes a request to a route.
+  ///
   /// - Parameters:
   ///   - route: The route to request.
   ///   - type: The type of value to decode the response into.
@@ -39,7 +48,7 @@ public struct URLRoutingClient<Route> {
     as type: Value.Type = Value.self,
     decoder: JSONDecoder? = nil
   ) async throws -> (value: Value, response: URLResponse) {
-    let (data, response) = try await self.request(route)
+    let (data, response) = try await self.data(for: route)
     do {
       return (try (decoder ?? self.decoder).decode(type, from: data), response)
     } catch {

--- a/Sources/URLRouting/Internal/Deprecations.swift
+++ b/Sources/URLRouting/Internal/Deprecations.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// NB: Deprecated after 0.1.0:
+
+extension URLRoutingClient {
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  @available(*, deprecated, renamed: "responseData(for:as:decoder:)")
+  public func request<Value: Decodable>(
+    _ route: Route,
+    as type: Value.Type = Value.self,
+    decoder: JSONDecoder? = nil
+  ) async throws -> (value: Value, response: URLResponse) {
+    try await self.decodedResponse(for: route, as: type, decoder: decoder)
+  }
+}

--- a/Sources/URLRouting/Printing.swift
+++ b/Sources/URLRouting/Printing.swift
@@ -51,7 +51,7 @@ extension ParserPrinter where Input == URLRequestData {
 /// let authenticatedRouter = router
 ///   .baseRequestData(.init(headers: ["X-PointFree-Session": ["deadbeef"]]))
 ///
-/// try authenticatedRouter.response(for: .home)
+/// try authenticatedRouter.request(for: .home)
 ///   .value(forHTTPHeaderField: "x-pointfree-session")
 /// // "deadbeef"
 /// ```

--- a/Sources/URLRouting/Printing.swift
+++ b/Sources/URLRouting/Printing.swift
@@ -51,7 +51,7 @@ extension ParserPrinter where Input == URLRequestData {
 /// let authenticatedRouter = router
 ///   .baseRequestData(.init(headers: ["X-PointFree-Session": ["deadbeef"]]))
 ///
-/// try authenticatedRouter.request(for: .home)
+/// try authenticatedRouter.response(for: .home)
 ///   .value(forHTTPHeaderField: "x-pointfree-session")
 /// // "deadbeef"
 /// ```

--- a/Sources/URLRouting/Scheme.swift
+++ b/Sources/URLRouting/Scheme.swift
@@ -8,6 +8,10 @@
 ///   ...
 /// }
 /// ```
+///
+/// > Note: Do not use the `Scheme` parser for the purpose of preferring to print a particular
+/// > scheme from your router. Instead, consider using ``BaseURLPrinter`` via the `baseURL` and
+/// > `baseRequestData` methods on routers.
 public struct Scheme: ParserPrinter {
   @usableFromInline
   let name: String
@@ -17,11 +21,6 @@ public struct Scheme: ParserPrinter {
 
   /// A parser of the `https` scheme.
   public static let https = Self("https")
-
-  /// A parser of custom schemes.
-  public static func custom(_ scheme: String) -> Self {
-    Self(scheme)
-  }
 
   /// Initializes a scheme parser with a scheme name.
   ///

--- a/Tests/URLRoutingTests/URLRoutingClientTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingClientTests.swift
@@ -19,7 +19,7 @@ class URLRoutingClientTests: XCTestCase {
       let sut = URLRoutingClient<AppRoute>(request: { _ in
         ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
       })
-      let response = try await sut.request(.test, as: Response.self)
+      let response = try await sut.responseData(for: .test, as: Response.self)
       XCTAssertEqual(response.value, .init(decodableValue: "result"))
     }
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
@@ -36,7 +36,7 @@ class URLRoutingClientTests: XCTestCase {
         request: { _ in
           ("{\"decodable_value\":\"result\"}".data(using: .utf8)!, URLResponse())
         }, decoder: customDecoder)
-      let response = try await sut.request(.test, as: Response.self)
+      let response = try await sut.responseData(for: .test, as: Response.self)
       XCTAssertEqual(response.value, .init(decodableValue: "result"))
     }
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
@@ -53,7 +53,7 @@ class URLRoutingClientTests: XCTestCase {
         request: { _ in
           ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
         }, decoder: customDecoder)
-      let response = try await sut.request(.test, as: Response.self, decoder: .init())
+      let response = try await sut.responseData(for: .test, as: Response.self, decoder: .init())
       XCTAssertEqual(response.value, .init(decodableValue: "result"))
     }
   #endif

--- a/Tests/URLRoutingTests/URLRoutingClientTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingClientTests.swift
@@ -19,7 +19,7 @@ class URLRoutingClientTests: XCTestCase {
       let sut = URLRoutingClient<AppRoute>(request: { _ in
         ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
       })
-      let response = try await sut.responseData(for: .test, as: Response.self)
+      let response = try await sut.decodedResponse(for: .test, as: Response.self)
       XCTAssertEqual(response.value, .init(decodableValue: "result"))
     }
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
@@ -36,7 +36,7 @@ class URLRoutingClientTests: XCTestCase {
         request: { _ in
           ("{\"decodable_value\":\"result\"}".data(using: .utf8)!, URLResponse())
         }, decoder: customDecoder)
-      let response = try await sut.responseData(for: .test, as: Response.self)
+      let response = try await sut.decodedResponse(for: .test, as: Response.self)
       XCTAssertEqual(response.value, .init(decodableValue: "result"))
     }
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
@@ -53,7 +53,7 @@ class URLRoutingClientTests: XCTestCase {
         request: { _ in
           ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
         }, decoder: customDecoder)
-      let response = try await sut.responseData(for: .test, as: Response.self, decoder: .init())
+      let response = try await sut.decodedResponse(for: .test, as: Response.self, decoder: .init())
       XCTAssertEqual(response.value, .init(decodableValue: "result"))
     }
   #endif

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -56,7 +56,6 @@ class URLRoutingTests: XCTestCase {
     let name = try p.parse(&request)
     XCTAssertEqual("Hello", name)
     XCTAssertEqual(["x-haha": ["Blob"]], request.headers)
-    XCTAssertEqual(["X-Haha": ["Blob"]], request.headers.fields)
   }
 
   func testQuery() throws {

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -55,7 +55,8 @@ class URLRoutingTests: XCTestCase {
 
     let name = try p.parse(&request)
     XCTAssertEqual("Hello", name)
-    XCTAssertEqual(["X-Haha": ["Blob"]], request.headers)
+    XCTAssertEqual(["x-haha": ["Blob"]], request.headers)
+    XCTAssertEqual(["X-Haha": ["Blob"]], request.headers.fields)
   }
 
   func testQuery() throws {


### PR DESCRIPTION
- Rename `URLRoutingClient.request(_:...)` to `decodedResponse(for:)`
- Add `URLRoutingClient.data(for:)`
