### PR TITLE
Adds URLRequestOption

### DIFF
--- a/Sources/URLRouting/Parsing/ParserPrinter.swift
+++ b/Sources/URLRouting/Parsing/ParserPrinter.swift
@@ -28,6 +28,12 @@ extension Parser where Input == URLRequestData {
 }
 
 extension ParserPrinter where Input == URLRequestData {
+    @inlinable
+    public func option<Option: URLRequestOption>(_ type: Option.Type, for route: Output) -> Option.Value {
+        let value = try? self.print(route)[option: type]
+        return value ?? Option.defaultValue
+    }
+
   @inlinable
   public func request(for route: Output) throws -> URLRequest {
     guard let request = try URLRequest(data: self.print(route))

--- a/Sources/URLRouting/URLRequestData.swift
+++ b/Sources/URLRouting/URLRequestData.swift
@@ -50,6 +50,15 @@ public struct URLRequestData: Equatable, _EmptyInitializable {
   /// The user subcomponent of the request URL.
   public var user: String?
 
+  /// Configurable custom request options
+  public var options: URLRequestOptions = .init([:])
+
+  /// Accessor for request options.
+  public subscript<Option: URLRequestOption>(option type: Option.Type) -> Option.Value {
+    get { options[option: type] }
+    set { options[option: type] = newValue }
+  }
+
   /// Initializes an empty URL request.
   public init() {}
 
@@ -79,6 +88,7 @@ public struct URLRequestData: Equatable, _EmptyInitializable {
     query: [String: [String?]] = [:],
     fragment: String? = nil,
     headers: [String: [String?]] = [:],
+    options: URLRequestOptions = .init([:]),
     body: Data? = nil
   ) {
     self.body = body
@@ -86,6 +96,7 @@ public struct URLRequestData: Equatable, _EmptyInitializable {
     self.headers = .init(headers.mapValues { $0.map { $0?[...] }[...] }, isNameCaseSensitive: false)
     self.host = host
     self.method = method
+      self.options = options
     self.password = password
     self.path = path.split(separator: "/")[...]
     self.port = port

--- a/Sources/URLRouting/URLRequestOption.swift
+++ b/Sources/URLRouting/URLRequestOption.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// A protocol used to attach custom options to a request.
+public protocol URLRequestOption {
+    associatedtype Value
+
+    static var defaultValue: Value { get }
+}
+
+public struct URLRequestOptions {
+    public var values = [ObjectIdentifier: Any]()
+
+    public init(_ values: [ObjectIdentifier: Any]) {
+        self.values = values
+    }
+
+    public init<Option>(_ option: Option) {
+        self.values = [ObjectIdentifier(Option.self): option]
+    }
+
+    @usableFromInline
+    init(_ options: [URLRequestOptions]) {
+        values = options.reduce(into: [:]) { partialResult, option in
+            partialResult.merge(option.values, uniquingKeysWith: { $1 })
+        }
+    }
+
+    public subscript<Option: URLRequestOption>(option type: Option.Type) -> Option.Value {
+        get {
+            let key = ObjectIdentifier(type)
+            guard let value = values[key] else {
+                return type.defaultValue
+            }
+            guard let value = value as? Option.Value else {
+                return type.defaultValue
+            }
+            return value
+        }
+        set {
+            let key = ObjectIdentifier(type)
+            values[key] = newValue
+        }
+    }
+}
+
+extension URLRequestOptions: Equatable {
+    public static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.values.keys == rhs.values.keys
+    }
+}
+
+@resultBuilder
+public enum OptionsBuilder {
+    public static func buildBlock(_ components: URLRequestOptions...) -> URLRequestOptions {
+        URLRequestOptions(components)
+    }
+    public static func buildBlock<O1: URLRequestOption>(_ option1: O1) -> URLRequestOptions {
+        URLRequestOptions(option1)
+    }
+    public static func buildBlock<O1: URLRequestOption, O2: URLRequestOption>(_ option1: O1, _ option2: O2) -> URLRequestOptions {
+        URLRequestOptions([URLRequestOptions(option1), URLRequestOptions(option2)])
+    }
+    public static func buildBlock<O1: URLRequestOption, O2: URLRequestOption, O3: URLRequestOption>(_ option1: O1, _ option2: O2, _ option3: O3) -> URLRequestOptions {
+        URLRequestOptions([URLRequestOptions(option1), URLRequestOptions(option2), URLRequestOptions(option3)])
+    }
+}
+
+/// Parses a request's options
+///
+/// Useful for adding custom configuration options to a request
+///
+/// For example,
+///
+public struct Options: ParserPrinter {
+
+    public let options: URLRequestOptions
+
+    @inlinable
+    public init(@OptionsBuilder build: () -> URLRequestOptions) {
+        options = .init(build().values)
+    }
+
+    @inlinable
+    public func parse(_ input: inout URLRequestData) {
+        // These are client side options only
+    }
+
+    @inlinable
+    public func print(_ output: (), into input: inout URLRequestData) {
+        input.options = options
+    }
+}
+

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -245,4 +245,14 @@ class URLRoutingTests: XCTestCase {
       )?.url?.absoluteString
     )
   }
+
+
+    func testOptions() throws {
+        enum TestOption: URLRequestOption {
+            static var defaultValue: Self = .foo
+            case foo, bar
+        }
+        XCTAssertEqual(.foo, Options { }.print()[option: TestOption.self])
+        XCTAssertEqual(.bar, Options { TestOption.bar }.print()[option: TestOption.self])
+    }
 }


### PR DESCRIPTION
Allows the framework consumer to attach (on a per request basis) "options" to requests which can be accessed inside the client. 

For example, you might want to build a network client which supports advanced features such as de-duplication, throttling, caching, authentication, retrying. Typically these features would require some kind of configuration, for example, perhaps not all requests should be cached, or the retry strategy might be different for some endpoints. Therefore, we require a mechanism to specify _request options_ to each `Route`, which we can retrieve inside the client. This is inspired by SwiftUI's EnvironmentValues, and from Dave de Long's [blog post](https://davedelong.com/blog/2020/07/09/http-in-swift-part-8-request-options/) on Request Options. 

First, framework consumers would define an option, lets say we want our client to cache response on a per request basis, we could define an option as follow:

```swift
enum CacheOption: URLRequestOption {
  static var defaultValue: Self = .always
  case always, never
}

enum ThrottleOption: URLRequestOption {
  static var defaultValue: Self = .always
  case always, never
}
```
The protocol, `URLRequestOption` is provided by the _URLRouting_ library. Similar to how we use `EnvironmentValues` in SwiftUI, we can provide a convenience accessor:

```swift
extension ParserPrinter where Input == URLRequestData {
    func cacheOption(for route: Output) -> CacheOption {
        option(CacheOption.self, for: route)
    }

    func throttleOption(for route: Output) -> ThrottleOption {
        option(ThrottleOption.self, for: route)
    }
}
```

Inside our router, we can then specify any options, e.g.

```swift
static let router = OneOf {
  Route(.case(.dashboard)) {
    Path { "dashboard" }
    Options {
        CacheOption.never
        ThrottleOption.never
    }
  }
}
```

Finally, inside a custom URLClient, we can now query the value of this option for every request.

```swift
extension URLRoutingClient {
    public static func connection<R: ParserPrinter>(
        router: R,
        session: URLSession = .shared,
        decoder: JSONDecoder = .init()
    ) -> Self
    where R.Input == URLRequestData, R.Output == Route {
        Self.init(
            request: { route in
                // Check request options as part of fetching this route
                let cacheOption = router.cacheOption(for: route)

                // etc
            },
            decoder: decoder
        )
    }
}
```

This PR provides the mechanism to specify user-defined options as part of a `Route`, and then access them later via the router, or `URLRequestData`. It does not provide any built in `URLRequestOption` types, nor does it consume any inside the default `URLClient` which ships with the framework.

It is intended that framework consumers would likely define their own Route options for their own purposes, and so would likely have their own network stack/client. 

Very happy to take any feedback or thoughts on this - especially how it works! And of course, the naming. Also, if there is a way for me to achieve this without changing the current framework - that would be great too. I have already tried composing `URLRequestData` inside my own `URLRequest` container which handles the options. This does not work very well, because ultimately, we need to specify the options as part of the Route.