### PR TITLE
Add URL Fragment parser and test

### DIFF
--- a/Sources/URLRouting/Fragment.swift
+++ b/Sources/URLRouting/Fragment.swift
@@ -1,0 +1,49 @@
+import Parsing
+
+/// Parses a request's fragment subcomponent with a substring parser.
+public struct Fragment<ValueParser: Parser>: Parser where ValueParser.Input == Substring {
+  
+  @usableFromInline
+  let valueParser: ValueParser
+  
+  /// Initializes a fragment parser that parses the fragment as a string in its entirety.
+  @inlinable
+  public init()
+  where ValueParser == Parsers.MapConversion<Parsers.ReplaceError<Rest<Substring>>, Conversions.SubstringToString> {
+    self.valueParser = Rest().replaceError(with: "").map(.string)
+  }
+  
+  /// Initializes a fragment parser.
+  ///
+  /// - Parameter value: A parser that parses the fragment's substring value into something
+  ///   more well-structured.
+  @inlinable
+  public init(@ParserBuilder value: () -> ValueParser) {
+    self.valueParser = value()
+  }
+  
+  /// Initializes a fragment parser.
+  ///
+  /// - Parameter value: A conversion that transforms the fragment's substring value into
+  ///   some other type.
+  @inlinable
+  public init<C>(_ value: C)
+  where ValueParser == Parsers.MapConversion<Parsers.ReplaceError<Rest<Substring>>, C> {
+    self.valueParser = Rest().replaceError(with: "").map(value)
+  }
+  
+  @inlinable
+  public func parse(_ input: inout URLRequestData) throws -> ValueParser.Output {
+    guard var fragment = input.fragment?[...] else { throw RoutingError() }
+    let output = try self.valueParser.parse(&fragment)
+    input.fragment = String(fragment)
+    return output
+  }
+}
+
+extension Fragment: ParserPrinter where ValueParser: ParserPrinter {
+  @inlinable
+  public func print(_ output: ValueParser.Output, into input: inout URLRequestData) rethrows {
+    input.fragment = String(try self.valueParser.print(output))
+  }
+}

--- a/Sources/URLRouting/Printing.swift
+++ b/Sources/URLRouting/Printing.swift
@@ -84,6 +84,7 @@ where Upstream.Input == URLRequestData {
     if let port = self.defaultRequestData.port { input.port = port }
     input.path.prepend(contentsOf: self.defaultRequestData.path)
     input.query.fields.merge(self.defaultRequestData.query.fields) { $1 + $0 }
+    if let fragment = self.defaultRequestData.fragment { input.fragment = fragment }
     input.headers.fields.merge(self.defaultRequestData.headers.fields) { $1 + $0 }
   }
 }

--- a/Sources/URLRouting/URLRequestData+Foundation.swift
+++ b/Sources/URLRouting/URLRequestData+Foundation.swift
@@ -35,6 +35,7 @@ extension URLRequestData {
       query: components.queryItems?.reduce(into: [:]) { query, item in
         query[item.name, default: []].append(item.value)
       } ?? [:],
+      fragment: components.fragment,
       headers: request.allHTTPHeaderFields?.mapValues {
         $0.split(separator: ",", omittingEmptySubsequences: false).map { String($0) }
       } ?? [:],
@@ -82,6 +83,7 @@ extension URLComponents {
           values.map { URLQueryItem(name: name, value: $0.map(String.init)) }
         }
     }
+    self.fragment = data.fragment
   }
 }
 

--- a/Sources/URLRouting/URLRequestData.swift
+++ b/Sources/URLRouting/URLRequestData.swift
@@ -7,6 +7,9 @@ import Foundation
 public struct URLRequestData: Equatable, _EmptyInitializable {
   /// The request body.
   public var body: Data?
+  
+  /// The fragment subcomponent of the request URL.
+  public var fragment: String?
 
   /// The request headers.
   ///
@@ -61,6 +64,7 @@ public struct URLRequestData: Equatable, _EmptyInitializable {
   ///   - port: The port subcomponent of the request URL.
   ///   - path: An array of the request URL's path components.
   ///   - query: The query subcomponent of the request URL.
+  ///   - fragment: The fragment subcomponent of the request URL.
   ///   - headers: The request headers.
   ///   - body: The request body.
   @inlinable
@@ -73,10 +77,12 @@ public struct URLRequestData: Equatable, _EmptyInitializable {
     port: Int? = nil,
     path: String = "",
     query: [String: [String?]] = [:],
+    fragment: String? = nil,
     headers: [String: [String?]] = [:],
     body: Data? = nil
   ) {
     self.body = body
+    self.fragment = fragment
     self.headers = .init(headers.mapValues { $0.map { $0?[...] }[...] }, isNameCaseSensitive: false)
     self.host = host
     self.method = method
@@ -147,6 +153,7 @@ extension URLRequestData: Codable {
       port: try container.decodeIfPresent(Int.self, forKey: .port),
       path: try container.decodeIfPresent(String.self, forKey: .path) ?? "",
       query: try container.decodeIfPresent([String: [String?]].self, forKey: .query) ?? [:],
+      fragment: try container.decodeIfPresent(String.self, forKey: .fragment),
       headers: try container.decodeIfPresent([String: [String?]].self, forKey: .headers) ?? [:],
       body: try container.decodeIfPresent(Data.self, forKey: .body)
     )
@@ -156,6 +163,7 @@ extension URLRequestData: Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encodeIfPresent(self.body.map(Array.init), forKey: .body)
+    try container.encodeIfPresent(self.fragment, forKey: .fragment)
     if !self.headers.isEmpty {
       try container.encode(
         self.headers.fields.mapValues { $0.map { $0.map(String.init) } },
@@ -180,6 +188,7 @@ extension URLRequestData: Codable {
   @usableFromInline
   enum CodingKeys: CodingKey {
     case body
+    case fragment
     case headers
     case host
     case method
@@ -196,6 +205,7 @@ extension URLRequestData: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.body)
+    hasher.combine(self.fragment)
     hasher.combine(self.method)
     hasher.combine(self.headers)
     hasher.combine(self.host)


### PR DESCRIPTION
I had a need to be able to parse the fragment of a URL, which also happens to address #28.

## Included In This PR:

- Adds an optional `fragment` property to the `URLRequestData` type
- Adds support for printing the `fragment`, if present
- Implements a `Fragment` parser/printer
- Adds relevant documentation
- Implements fragment unit tests



