### PR TITLE
Add SPI DocC support

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -9,3 +9,4 @@ builder:
     scheme: URLRouting
   - platform: watchos
     scheme: URLRouting
+  - documentation_targets: [URLRouting]

--- a/Package.swift
+++ b/Package.swift
@@ -40,3 +40,10 @@ let package = Package(
     ),
   ]
 )
+
+#if swift(>=5.6)
+  // Add the documentation compiler plugin if possible
+  package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+  )
+#endif


### PR DESCRIPTION
Steps from https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/
