### PR TITLE
Add URL Host parser and test

### DIFF
--- a/Sources/URLRouting/Host.swift
+++ b/Sources/URLRouting/Host.swift
@@ -1,0 +1,43 @@
+/// Parses a request's host.
+///
+/// Used to require a particular host at a particular endpoint.
+///
+/// ```swift
+/// Route(.case(SiteRoute.custom)) {
+///   Host("custom")  // Only routes scheme://custom requests
+///   ...
+/// }
+/// ```
+///
+/// > Note: Do not use the `Host` parser for the purpose of preferring to print a particular
+/// > host from your router. Instead, consider using ``BaseURLPrinter`` via the `baseURL` and
+/// > `baseRequestData` methods on routers.
+public struct Host: ParserPrinter {
+  @usableFromInline
+  let name: String
+
+  /// A parser of custom hosts.
+  public static func custom(_ host: String) -> Self {
+    Self(host)
+  }
+
+  /// Initializes a host parser with a host name.
+  ///
+  /// - Parameter name: A host name.
+  @inlinable
+  public init(_ name: String) {
+    self.name = name
+  }
+
+  @inlinable
+  public func parse(_ input: inout URLRequestData) throws {
+    guard let host = input.host else { throw RoutingError() }
+    try self.name.parse(host)
+    input.host = nil
+  }
+
+  @inlinable
+  public func print(_ output: (), into input: inout URLRequestData) {
+    input.host = self.name
+  }
+}

--- a/Sources/URLRouting/Scheme.swift
+++ b/Sources/URLRouting/Scheme.swift
@@ -24,7 +24,7 @@ public struct Scheme: ParserPrinter {
 
   /// Initializes a scheme parser with a scheme name.
   ///
-  /// - Parameter name: A method name.
+  /// - Parameter name: A scheme name.
   @inlinable
   public init(_ name: String) {
     self.name = name

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -12,6 +12,11 @@ class URLRoutingTests: XCTestCase {
     XCTAssertEqual(try Method.post.print(), URLRequestData(method: "POST"))
   }
 
+  func testHost() {
+    XCTAssertNoThrow(try Host.custom("foo").parse(URLRequestData(host: "foo")))
+    XCTAssertEqual(try Host.custom("foo").print(), URLRequestData(host: "foo"))
+  }
+
   func testScheme() {
     XCTAssertNoThrow(try Scheme.http.parse(URLRequestData(scheme: "http")))
     XCTAssertEqual(try Scheme.http.print(), URLRequestData(scheme: "http"))


### PR DESCRIPTION
## 💬 Summary of Changes

- Implements a host parser to support requiring a specific host. This is particularly useful when parsing older style custom schemes on iOS that use the host, rather than path as a differentiator.

## ✅ Checklist

- [x] 🧐 Performed a self-review of the changes.
- [x] ✅ Added tests to cover changes.
- [x] 🏎 Ran Unit Tests before opening PR.

