### PR TITLE
Fix compilation errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 
 import PackageDescription
 
@@ -15,9 +15,9 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "0.5.0"),
-    .package(url: "https://github.com/pointfreeco/swift-parsing", .branch("swift-5-7")),
+    .package(url: "https://github.com/pointfreeco/swift-parsing", branch: "swift-5-7"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.3.0"),
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.1"),
+    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.1"),
   ],
   targets: [
     .target(
@@ -37,7 +37,7 @@ let package = Package(
       name: "swift-url-routing-benchmark",
       dependencies: [
         "URLRouting",
-        .product(name: "Benchmark", package: "Benchmark"),
+        .product(name: "Benchmark", package: "swift-benchmark"),
       ]
     ),
     .executableTarget(

--- a/Sources/URLRouting/Body.swift
+++ b/Sources/URLRouting/Body.swift
@@ -26,7 +26,7 @@ public struct Body<Bytes: Parser>: Parser where Bytes.Input == Data {
   /// - Parameter bytesConversion: A conversion that transforms bytes into some other type.
   @inlinable
   public init<C>(_ bytesConversion: C)
-  where Bytes == Parsers.MapConversion<Parsers.ReplaceError<Rest<Bytes.Input>>, C> {
+  where Bytes == Parsers.MapConversion<Parsers.ReplaceError<Rest<Data>>, C> {
     self.bytesParser = Rest().replaceError(with: .init()).map(bytesConversion)
   }
 

--- a/Sources/URLRouting/Client/Client.swift
+++ b/Sources/URLRouting/Client/Client.swift
@@ -92,9 +92,7 @@ extension URLRoutingClient {
         var dataTask: URLSessionDataTask?
         let cancel: () -> Void = { dataTask?.cancel() }
 
-        return try await withTaskCancellationHandler(
-          handler: { cancel() },
-          operation: {
+          return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
               dataTask = session.dataTask(with: request) { data, response, error in
                 guard
@@ -109,8 +107,9 @@ extension URLRoutingClient {
               }
               dataTask?.resume()
             }
+          } onCancel: {
+              cancel()
           }
-        )
       },
       decoder: decoder
     )

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -9,7 +9,7 @@ import XCTest
 class URLRoutingTests: XCTestCase {
   func testMethod() {
 
-    Path {
+    _ = Path {
       "sheet"
       Optionally { Int.parser() }
     }


### PR DESCRIPTION
Build fails with  "Command SwiftEmitModule failed with a nonzero exit code" error
```
1.	Apple Swift version 5.7.1 (swiftlang-5.7.1.135.3 clang-1400.0.29.51)
2.	Compiling with the current language version
3.	While evaluating request TypeCheckSourceFileRequest(source_file "/Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift")
4.	While type-checking 'Body' (at /Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift:4:8)
5.	While type-checking 'init(_:)' (at /Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift:28:10)
6.	While evaluating request InterfaceTypeRequest(URLRouting.(file).Body.init(_:)@/Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift:28:10)
7.	While evaluating request GenericSignatureRequest(URLRouting.(file).Body.init(_:)@/Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift:28:10)
8.	While evaluating request InferredGenericSignatureRequest(URLRouting, <Bytes where Bytes : Parser, Bytes.Input == Data>, <C>, URLRouting.(file).Body.init(_:)@/Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift:28:10, {}, {(C, C)}, 0)
9.	While evaluating request InferredGenericSignatureRequestRQM(<Bytes where Bytes : Parser, Bytes.Input == Data>, <C>, URLRouting.(file).Body.init(_:)@/Users/danil/Downloads/swift-url-routing-swift-5-7/Sources/URLRouting/Body.swift:28:10, {}, {(C, C)}, 0)
```