### PR TITLE
remove extra paren in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import URLRouting
 
 let appRouter = OneOf {
   // GET /books
-  Route(.case(AppRoute.books))) {
+  Route(.case(AppRoute.books)) {
     Path { "books" }
   }
 


### PR DESCRIPTION
i copy-pasted the example from the readme and was confused for a few minutes because it didn't compile, and the error was a little hard to recognize. turns out there's a stray extra parentheses.