### PR TITLE
Update swift-parsing to 0.11.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-parsing",
         "state": {
           "branch": null,
-          "revision": "bc92e84968990b41640214b636667f35b6e5d44c",
-          "version": "0.10.0"
+          "revision": "4bb9192468c1a8be57f46b7d6fd4f561c88b2195",
+          "version": "0.11.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "0.5.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.3"),
-    .package(url: "https://github.com/pointfreeco/swift-parsing", from: "0.10.0"),
+    .package(url: "https://github.com/pointfreeco/swift-parsing", from: "0.11.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.3.0"),
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.1"),
   ],


### PR DESCRIPTION
Update to the swift-parsing dependency to 0.11.0.

https://github.com/pointfreeco/swift-parsing/releases/tag/0.11.0

This gives access to the Swift 5.7 changes that were made in this release.