### PR TITLE
fix: Fixes links in documentation that point to swift-parsing library.

### DIFF
--- a/Sources/URLRouting/Documentation.docc/URLRouting.md
+++ b/Sources/URLRouting/Documentation.docc/URLRouting.md
@@ -4,8 +4,8 @@ A bidirectional URL router with more type safety and less fuss. This library is 
 
 ## Additional Resources
 
-- [GitHub Repo](https://github.com/pointfreeco/swift-parsing)
-- [Discussions](https://github.com/pointfreeco/swift-parsing/discussions)
+- [GitHub Repo](https://github.com/pointfreeco/swift-url-routing)
+- [Discussions](https://github.com/pointfreeco/swift-url-routing/discussions)
 - [Point-Free Videos](https://www.pointfree.co/collections/parsing)
 
 ## Overview


### PR DESCRIPTION
Just a minor update that fixes links in the documentation that point to the `swift-parsing` library.