### PR TITLE
Fix GET form query encoding

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "7bbd97af585672a3dcdf6575ad37b339ad41b579",
-        "version" : "1.13.0"
+        "revision" : "d9308ad679143c26a30dec52daefe82f54af2b82",
+        "version" : "1.13.1"
       }
     }
   ],

--- a/Sources/URLRouting/Parsing/ParserPrinter.swift
+++ b/Sources/URLRouting/Parsing/ParserPrinter.swift
@@ -62,10 +62,7 @@ extension ParserPrinter where Input == URLRequestData {
       var components = URLComponents()
       components.path = "/\(data.path.joined(separator: "/"))"
       if !data.query.isEmpty {
-        components.queryItems = data.query
-          .flatMap { name, values in
-            values.map { URLQueryItem(name: name, value: $0.map(String.init)) }
-          }
+        components.percentEncodedQueryItems = data.query.urlFormEncodedQueryItems
       }
       return components.string ?? "#route-not-found"
     } catch {

--- a/Sources/URLRouting/URLRequestData+Foundation.swift
+++ b/Sources/URLRouting/URLRequestData+Foundation.swift
@@ -33,8 +33,8 @@ extension URLRequestData {
       host: components.host,
       port: components.port,
       path: components.path,
-      query: components.queryItems?.reduce(into: [:]) { query, item in
-        query[item.name, default: []].append(item.value)
+      query: components.percentEncodedQueryItems?.reduce(into: [:]) { query, item in
+        query[item.name.urlFormDecoded, default: []].append(item.value?.urlFormDecoded)
       } ?? [:],
       fragment: components.fragment,
       headers: .init(
@@ -81,13 +81,38 @@ extension URLComponents {
     self.port = data.port
     self.path = "/\(data.path.joined(separator: "/"))"
     if !data.query.isEmpty {
-      self.queryItems = data.query
-        .flatMap { name, values in
-          values.map { URLQueryItem(name: name, value: $0.map(String.init)) }
-        }
+      self.percentEncodedQueryItems = data.query.urlFormEncodedQueryItems
     }
     self.fragment = data.fragment
   }
+}
+
+extension URLRequestData.Fields {
+  @usableFromInline
+  var urlFormEncodedQueryItems: [URLQueryItem] {
+    self.flatMap { name, values in
+      values.map { URLQueryItem(name: name.urlFormEncoded, value: $0.map(\.urlFormEncoded)) }
+    }
+  }
+}
+
+extension StringProtocol {
+  @usableFromInline
+  var urlFormDecoded: String {
+    let spaced = self.replacingOccurrences(of: "+", with: " ")
+    return spaced.removingPercentEncoding ?? spaced
+  }
+
+  @usableFromInline
+  var urlFormEncoded: String {
+    self.addingPercentEncoding(withAllowedCharacters: .urlQueryItemAllowed) ?? String(self)
+  }
+}
+
+extension CharacterSet {
+  @usableFromInline
+  static let urlQueryItemAllowed = CharacterSet.urlQueryAllowed
+    .subtracting(CharacterSet(charactersIn: "+&="))
 }
 
 extension URLRequest {

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -121,8 +121,6 @@ struct URLRoutingTests {
     )
   }
 
-  func testQueryDefault() throws {
-
   @Test
   func queryDefault() throws {
     let p = Query {

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -109,10 +109,10 @@ struct URLRoutingTests {
     }
 
     var request = URLRequestData(string: "/search?q=get+set+binding")!
-    #expect("get set binding" == try p.parse(&request))
+    try #expect("get set binding" == p.parse(&request))
 
     request = URLRequestData(string: "/search?q=%22%240%20%2B%201%22")!
-    #expect(#""$0 + 1""# == try p.parse(&request))
+    try #expect(#""$0 + 1""# == p.parse(&request))
 
     #expect("/?q=%22$0%20%2B%201%22" == p.path(for: #""$0 + 1""#))
     #expect(

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -87,6 +87,24 @@ class URLRoutingTests: XCTestCase {
     )
   }
 
+  func testQueryFormEncoding() throws {
+    let p = Query {
+      Field("q")
+    }
+
+    var request = URLRequestData(string: "/search?q=get+set+binding")!
+    XCTAssertEqual("get set binding", try p.parse(&request))
+
+    request = URLRequestData(string: "/search?q=%22%240%20%2B%201%22")!
+    XCTAssertEqual(#""$0 + 1""#, try p.parse(&request))
+
+    XCTAssertEqual("/?q=%22$0%20%2B%201%22", p.path(for: #""$0 + 1""#))
+    XCTAssertEqual(
+      "/?q=%22$0%20%2B%201%22",
+      URLComponents(data: try p.print(#""$0 + 1""#)).string
+    )
+  }
+
   func testQueryDefault() throws {
     let p = Query {
       Field("page", default: 1) {


### PR DESCRIPTION
GET-based queries, which use `+` instead of `%20` for spaces, weren't being handled properly.