### PR TITLE
Swift Testing Migration

### DIFF
--- a/Tests/URLRoutingTests/RoutingErrorTests.swift
+++ b/Tests/URLRoutingTests/RoutingErrorTests.swift
@@ -1,9 +1,12 @@
+import Foundation
 import Parsing
+import Testing
 import URLRouting
 import XCTest
 
-class RoutingErrorTests: XCTestCase {
-  func testError() {
+struct RoutingErrorTests {
+  @Test
+  func error() throws {
     enum BookRoute {
       case fetch
     }
@@ -116,20 +119,22 @@ class RoutingErrorTests: XCTestCase {
         }
       }
     }
-
-    XCTAssertThrowsError(try SiteRouter().parse(URLRequestData(path: "/123"))) { error in
-      XCTAssertEqual(
-        """
-        error: unexpected input
-         --> input:1:2
-        1 | /123
-          |  ^ expected "about-us"
-          |  ^ expected "contact-us"
-          |  ^ expected end of input
-          |  ^ expected "users"
-        """,
-        "\(error)"
-      )
+    
+    let error = try #require(throws: (any Error).self) {
+      try SiteRouter().parse(URLRequestData(path: "/123"))
     }
+    
+    #expect(
+      """
+      error: unexpected input
+       --> input:1:2
+      1 | /123
+        |  ^ expected "about-us"
+        |  ^ expected "contact-us"
+        |  ^ expected end of input
+        |  ^ expected "users"
+      """ ==
+      String(describing: error)
+    )
   }
 }

--- a/Tests/URLRoutingTests/RoutingErrorTests.swift
+++ b/Tests/URLRoutingTests/RoutingErrorTests.swift
@@ -119,11 +119,11 @@ struct RoutingErrorTests {
         }
       }
     }
-    
+
     let error = try #require(throws: (any Error).self) {
       try SiteRouter().parse(URLRequestData(path: "/123"))
     }
-    
+
     #expect(
       """
       error: unexpected input
@@ -133,8 +133,7 @@ struct RoutingErrorTests {
         |  ^ expected "contact-us"
         |  ^ expected end of input
         |  ^ expected "users"
-      """ ==
-      String(describing: error)
+      """ == String(describing: error)
     )
   }
 }

--- a/Tests/URLRoutingTests/URLRoutingClientTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingClientTests.swift
@@ -57,7 +57,8 @@ struct URLRoutingClientTests {
         request: { _ in
           (Data(#"{"decodableValue":"result"}"#.utf8), URLResponse())
         }, decoder: customDecoder)
-      let response = try await sut.decodedResponse(for: .test, as: Response.self, decoder: JSONDecoder())
+      let response = try await sut.decodedResponse(
+        for: .test, as: Response.self, decoder: JSONDecoder())
       #expect(response.value == Response(decodableValue: "result"))
     }
   #endif

--- a/Tests/URLRoutingTests/URLRoutingClientTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingClientTests.swift
@@ -1,15 +1,17 @@
+import Foundation
 import Parsing
+import Testing
 import URLRouting
-import XCTest
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 
-class URLRoutingClientTests: XCTestCase {
+struct URLRoutingClientTests {
   #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    @Test
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-    func testJSONDecoder_noDecoder() async throws {
+    func jsonDecoder_noDecoder() async throws {
       struct Response: Equatable, Decodable {
         let decodableValue: String
       }
@@ -17,13 +19,14 @@ class URLRoutingClientTests: XCTestCase {
         case test
       }
       let sut = URLRoutingClient<AppRoute>(request: { _ in
-        ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
+        (Data(#"{"decodableValue":"result"}"#.utf8), URLResponse())
       })
       let response = try await sut.decodedResponse(for: .test, as: Response.self)
-      XCTAssertEqual(response.value, .init(decodableValue: "result"))
+      #expect(response.value == Response(decodableValue: "result"))
     }
+    @Test
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-    func testJSONDecoder_customDecoder() async throws {
+    func jsonDecoder_customDecoder() async throws {
       struct Response: Equatable, Decodable {
         let decodableValue: String
       }
@@ -34,13 +37,14 @@ class URLRoutingClientTests: XCTestCase {
       customDecoder.keyDecodingStrategy = .convertFromSnakeCase
       let sut = URLRoutingClient<AppRoute>(
         request: { _ in
-          ("{\"decodable_value\":\"result\"}".data(using: .utf8)!, URLResponse())
+          (Data(#"{"decodable_value":"result"}"#.utf8), URLResponse())
         }, decoder: customDecoder)
       let response = try await sut.decodedResponse(for: .test, as: Response.self)
-      XCTAssertEqual(response.value, .init(decodableValue: "result"))
+      #expect(response.value == Response(decodableValue: "result"))
     }
+    @Test
     @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-    func testJSONDecoder_customDecoderForRequest() async throws {
+    func jsonDecoder_customDecoderForRequest() async throws {
       struct Response: Equatable, Decodable {
         let decodableValue: String
       }
@@ -51,10 +55,10 @@ class URLRoutingClientTests: XCTestCase {
       customDecoder.keyDecodingStrategy = .convertFromSnakeCase
       let sut = URLRoutingClient<AppRoute>(
         request: { _ in
-          ("{\"decodableValue\":\"result\"}".data(using: .utf8)!, URLResponse())
+          (Data(#"{"decodableValue":"result"}"#.utf8), URLResponse())
         }, decoder: customDecoder)
-      let response = try await sut.decodedResponse(for: .test, as: Response.self, decoder: .init())
-      XCTAssertEqual(response.value, .init(decodableValue: "result"))
+      let response = try await sut.decodedResponse(for: .test, as: Response.self, decoder: JSONDecoder())
+      #expect(response.value == Response(decodableValue: "result"))
     }
   #endif
 }

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -39,19 +39,18 @@ struct URLRoutingTests {
   @Test
   func path() throws {
     #expect(try Path { Int.parser() }.parse(URLRequestData(path: "/123")) == 123)
-    
+
     let error = try #require(throws: (any Error).self) {
       try Path { Int.parser() }.parse(URLRequestData(path: "/123-foo"))
     }
-    
+
     #expect(
-        """
-        error: unexpected input
-         --> input:1:5
-        1 | /123-foo
-          |     ^ expected end of input
-        """ ==
-        String(describing: error)
+      """
+      error: unexpected input
+       --> input:1:5
+      1 | /123-foo
+        |     ^ expected end of input
+      """ == String(describing: error)
     )
   }
 
@@ -168,8 +167,8 @@ struct URLRoutingTests {
     request = try #require(URLRequestData(string: "/legal/privacy#faq"))
     #expect(try r.parse(&request) == AppRoute.privacyPolicy(section: "faq"))
     #expect(
-      try r.print(.privacyPolicy(section: "faq")) ==
-      URLRequestData(path: "/legal/privacy", fragment: "faq")
+      try r.print(.privacyPolicy(section: "faq"))
+        == URLRequestData(path: "/legal/privacy", fragment: "faq")
     )
   }
 
@@ -189,8 +188,8 @@ struct URLRoutingTests {
     var request = URLRequestData(headers: ["cookie": ["userId=42; isAdmin=true"]])
     #expect(try p.parse(&request) == Session(userId: 42, isAdmin: true))
     #expect(
-      try p.print(Session(userId: 42, isAdmin: true)) ==
-      URLRequestData(headers: ["cookie": ["userId=42; isAdmin=true"]])
+      try p.print(Session(userId: 42, isAdmin: true))
+        == URLRequestData(headers: ["cookie": ["userId=42; isAdmin=true"]])
     )
   }
 
@@ -207,8 +206,8 @@ struct URLRoutingTests {
     var request = URLRequestData(headers: ["cookie": [#"pf_session={"userId":42}; foo=bar"#]])
     #expect(try p.parse(&request) == Session(userId: 42))
     #expect(
-      try p.print(Session(userId: 42)) ==
-      URLRequestData(headers: ["cookie": [#"pf_session={"userId":42}"#]])
+      try p.print(Session(userId: 42))
+        == URLRequestData(headers: ["cookie": [#"pf_session={"userId":42}"#]])
     )
   }
 
@@ -224,23 +223,23 @@ struct URLRoutingTests {
     }
 
     #expect(
-      "https://api.pointfree.co/v1/episodes?token=deadbeef" ==
-      URLRequest(
-        data:
-          try router
-          .baseURL("https://api.pointfree.co/v1?token=deadbeef")
-          .print(.episodes)
-      )?.url?.absoluteString
+      "https://api.pointfree.co/v1/episodes?token=deadbeef"
+        == URLRequest(
+          data:
+            try router
+            .baseURL("https://api.pointfree.co/v1?token=deadbeef")
+            .print(.episodes)
+        )?.url?.absoluteString
     )
 
     #expect(
-      "http://localhost:8080/v1/episodes?token=deadbeef" ==
-      URLRequest(
-        data:
-          try router
-          .baseURL("http://localhost:8080/v1?token=deadbeef")
-          .print(.episodes)
-      )?.url?.absoluteString
+      "http://localhost:8080/v1/episodes?token=deadbeef"
+        == URLRequest(
+          data:
+            try router
+            .baseURL("http://localhost:8080/v1?token=deadbeef")
+            .print(.episodes)
+        )?.url?.absoluteString
     )
   }
 }

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -149,7 +149,7 @@ struct URLRoutingTests {
     request = try #require(URLRequestData(string: "#section1"))
     #expect(throws: Never.self) { try p3.parse(&request) }
     request = try #require(URLRequestData(string: "#section2"))
-    try #require(throws: (any Error).self) { try p3.parse(&request) }
+    #expect(throws: (any Error).self) { try p3.parse(&request) }
     #expect(try p3.print() == URLRequestData(fragment: "section1"))
 
     enum AppRoute: Equatable {

--- a/Tests/URLRoutingTests/URLRoutingTests.swift
+++ b/Tests/URLRoutingTests/URLRoutingTests.swift
@@ -1,45 +1,62 @@
+import Foundation
 import OrderedCollections
 import Parsing
+import Testing
 import URLRouting
-import XCTest
 
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
 
-class URLRoutingTests: XCTestCase {
-  func testMethod() {
-    XCTAssertNoThrow(try Method.post.parse(URLRequestData(method: "POST")))
-    XCTAssertEqual(try Method.post.print(), URLRequestData(method: "POST"))
+struct URLRoutingTests {
+  @Test
+  func method() throws {
+    #expect(throws: Never.self) {
+      try Method.post.parse(URLRequestData(method: "POST"))
+    }
+
+    #expect(try Method.post.print() == URLRequestData(method: "POST"))
   }
 
-  func testHost() {
-    XCTAssertNoThrow(try Host.custom("foo").parse(URLRequestData(host: "foo")))
-    XCTAssertEqual(try Host.custom("foo").print(), URLRequestData(host: "foo"))
+  @Test
+  func host() throws {
+    #expect(throws: Never.self) {
+      try Host.custom("foo").parse(URLRequestData(host: "foo"))
+    }
+
+    #expect(try Host.custom("foo").print() == URLRequestData(host: "foo"))
   }
 
-  func testScheme() {
-    XCTAssertNoThrow(try Scheme.http.parse(URLRequestData(scheme: "http")))
-    XCTAssertEqual(try Scheme.http.print(), URLRequestData(scheme: "http"))
+  @Test
+  func scheme() throws {
+    #expect(throws: Never.self) {
+      try Scheme.http.parse(URLRequestData(scheme: "http"))
+    }
+
+    #expect(try Scheme.http.print() == URLRequestData(scheme: "http"))
   }
 
-  func testPath() {
-    XCTAssertEqual(123, try Path { Int.parser() }.parse(URLRequestData(path: "/123")))
-    XCTAssertThrowsError(try Path { Int.parser() }.parse(URLRequestData(path: "/123-foo"))) {
-      error in
-      XCTAssertEqual(
+  @Test
+  func path() throws {
+    #expect(try Path { Int.parser() }.parse(URLRequestData(path: "/123")) == 123)
+    
+    let error = try #require(throws: (any Error).self) {
+      try Path { Int.parser() }.parse(URLRequestData(path: "/123-foo"))
+    }
+    
+    #expect(
         """
         error: unexpected input
          --> input:1:5
         1 | /123-foo
           |     ^ expected end of input
-        """,
-        "\(error)"
-      )
-    }
+        """ ==
+        String(describing: error)
+    )
   }
 
-  func testFormData() throws {
+  @Test
+  func formData() throws {
     let p = Body {
       FormData {
         Field("name", .string)
@@ -49,12 +66,13 @@ class URLRoutingTests: XCTestCase {
 
     var request = URLRequestData(body: .init("name=Blob&age=42&debug=1".utf8))
     let (name, age) = try p.parse(&request)
-    XCTAssertEqual("Blob", name)
-    XCTAssertEqual(42, age)
-    XCTAssertEqual("debug=1", request.body.map { String(decoding: $0, as: UTF8.self) })
+    #expect("Blob" == name)
+    #expect(42 == age)
+    #expect("debug=1" == request.body.map { String(decoding: $0, as: UTF8.self) })
   }
 
-  func testHeaders() throws {
+  @Test
+  func headers() throws {
     let p = Headers {
       Field("X-Haha", .string)
     }
@@ -65,11 +83,12 @@ class URLRoutingTests: XCTestCase {
     var request = URLRequestData(request: req)!
 
     let name = try p.parse(&request)
-    XCTAssertEqual("Hello", name)
-    XCTAssertEqual(["x-haha": ["Blob"]], request.headers)
+    #expect("Hello" == name)
+    #expect(["x-haha": ["Blob"]] == request.headers)
   }
 
-  func testQuery() throws {
+  @Test
+  func query() throws {
     let p = Query {
       Field("name")
       Field("age") { Int.parser() }
@@ -77,17 +96,15 @@ class URLRoutingTests: XCTestCase {
 
     var request = URLRequestData(string: "/?name=Blob&age=42&debug=1")!
     let (name, age) = try p.parse(&request)
-    XCTAssertEqual("Blob", name)
-    XCTAssertEqual(42, age)
-    XCTAssertEqual(["debug": ["1"]], request.query)
+    #expect("Blob" == name)
+    #expect(42 == age)
+    #expect(["debug": ["1"]] == request.query)
 
-    XCTAssertEqual(
-      try p.print(("Blob", 42)),
-      URLRequestData(query: ["name": ["Blob"], "age": ["42"]])
-    )
+    #expect(try p.print(("Blob", 42)) == URLRequestData(query: ["name": ["Blob"], "age": ["42"]]))
   }
 
-  func testQueryDefault() throws {
+  @Test
+  func queryDefault() throws {
     let p = Query {
       Field("page", default: 1) {
         Int.parser()
@@ -96,32 +113,21 @@ class URLRoutingTests: XCTestCase {
 
     var request = URLRequestData(string: "/")!
     let page = try p.parse(&request)
-    XCTAssertEqual(1, page)
-    XCTAssertEqual([:], request.query)
+    #expect(1 == page)
+    #expect([:] == request.query)
 
-    XCTAssertEqual(
-      try p.print(10),
-      URLRequestData(query: ["page": ["10"]])
-    )
-    XCTAssertEqual(
-      try p.print(1),
-      URLRequestData(query: [:])
-    )
+    #expect(try p.print(10) == URLRequestData(query: ["page": ["10"]]))
+    #expect(try p.print(1) == URLRequestData(query: [:]))
   }
 
-  func testFragment() throws {
+  @Test
+  func fragment() throws {
     // test default initializer
     let q1 = Fragment()
 
-    var request = try XCTUnwrap(URLRequestData(string: "#fragment"))
-    XCTAssertEqual(
-      "fragment",
-      try q1.parse(&request)
-    )
-    XCTAssertEqual(
-      URLRequestData(fragment: "fragment"),
-      try q1.print("fragment")
-    )
+    var request = try #require(URLRequestData(string: "#fragment"))
+    #expect(try q1.parse(&request) == "fragment")
+    #expect(try q1.print("fragment") == URLRequestData(fragment: "fragment"))
 
     struct Timestamp: Equatable, RawRepresentable {
       let rawValue: String
@@ -129,30 +135,22 @@ class URLRoutingTests: XCTestCase {
 
     // test conversion initializer
     let q2 = Fragment(.string.representing(Timestamp.self))
-    request = try XCTUnwrap(
-      URLRequestData(string: "https://www.pointfree.co/episodes/ep182-invertible-parsing-map#t802"))
-    XCTAssertEqual(
-      Timestamp(rawValue: "t802"),
-      try q2.parse(&request)
+    request = try #require(
+      URLRequestData(string: "https://www.pointfree.co/episodes/ep182-invertible-parsing-map#t802")
     )
-    XCTAssertEqual(
-      URLRequestData(fragment: "t802"),
-      try q2.print(Timestamp(rawValue: "t802"))
-    )
+    #expect(try q2.parse(&request) == Timestamp(rawValue: "t802"))
+    #expect(try q2.print(Timestamp(rawValue: "t802")) == URLRequestData(fragment: "t802"))
 
     // test parser builder initializer
     let p3 = Fragment {
       "section1"
     }
 
-    request = try XCTUnwrap(URLRequestData(string: "#section1"))
-    XCTAssertNoThrow(try p3.parse(&request))
-    request = try XCTUnwrap(URLRequestData(string: "#section2"))
-    XCTAssertThrowsError(try p3.parse(&request))
-    XCTAssertEqual(
-      .init(fragment: "section1"),
-      try p3.print()
-    )
+    request = try #require(URLRequestData(string: "#section1"))
+    #expect(throws: Never.self) { try p3.parse(&request) }
+    request = try #require(URLRequestData(string: "#section2"))
+    try #require(throws: (any Error).self) { try p3.parse(&request) }
+    #expect(try p3.print() == URLRequestData(fragment: "section1"))
 
     enum AppRoute: Equatable {
       case privacyPolicy(section: String)
@@ -167,18 +165,16 @@ class URLRoutingTests: XCTestCase {
       Fragment()
     }
 
-    request = try XCTUnwrap(URLRequestData(string: "/legal/privacy#faq"))
-    XCTAssertEqual(
-      .privacyPolicy(section: "faq"),
-      try r.parse(&request)
-    )
-    XCTAssertEqual(
-      .init(path: "/legal/privacy", fragment: "faq"),
-      try r.print(.privacyPolicy(section: "faq"))
+    request = try #require(URLRequestData(string: "/legal/privacy#faq"))
+    #expect(try r.parse(&request) == AppRoute.privacyPolicy(section: "faq"))
+    #expect(
+      try r.print(.privacyPolicy(section: "faq")) ==
+      URLRequestData(path: "/legal/privacy", fragment: "faq")
     )
   }
 
-  func testCookies() throws {
+  @Test
+  func cookies() throws {
     struct Session: Equatable {
       var userId: Int
       var isAdmin: Bool
@@ -191,17 +187,15 @@ class URLRoutingTests: XCTestCase {
     .map(.memberwise(Session.init(userId:isAdmin:)))
 
     var request = URLRequestData(headers: ["cookie": ["userId=42; isAdmin=true"]])
-    XCTAssertEqual(
-      Session(userId: 42, isAdmin: true),
-      try p.parse(&request)
-    )
-    XCTAssertEqual(
-      URLRequestData(headers: ["cookie": ["userId=42; isAdmin=true"]]),
-      try p.print(Session(userId: 42, isAdmin: true))
+    #expect(try p.parse(&request) == Session(userId: 42, isAdmin: true))
+    #expect(
+      try p.print(Session(userId: 42, isAdmin: true)) ==
+      URLRequestData(headers: ["cookie": ["userId=42; isAdmin=true"]])
     )
   }
 
-  func testJSONCookies() {
+  @Test
+  func jsonCookies() throws {
     struct Session: Codable, Equatable {
       var userId: Int
     }
@@ -211,17 +205,15 @@ class URLRoutingTests: XCTestCase {
     }
 
     var request = URLRequestData(headers: ["cookie": [#"pf_session={"userId":42}; foo=bar"#]])
-    XCTAssertEqual(
-      Session(userId: 42),
-      try p.parse(&request)
-    )
-    XCTAssertEqual(
-      URLRequestData(headers: ["cookie": [#"pf_session={"userId":42}"#]]),
-      try p.print(Session(userId: 42))
+    #expect(try p.parse(&request) == Session(userId: 42))
+    #expect(
+      try p.print(Session(userId: 42)) ==
+      URLRequestData(headers: ["cookie": [#"pf_session={"userId":42}"#]])
     )
   }
 
-  func testBaseURL() throws {
+  @Test
+  func baseURL() throws {
     enum AppRoute { case home, episodes }
 
     let router = OneOf {
@@ -231,8 +223,8 @@ class URLRoutingTests: XCTestCase {
       }
     }
 
-    XCTAssertEqual(
-      "https://api.pointfree.co/v1/episodes?token=deadbeef",
+    #expect(
+      "https://api.pointfree.co/v1/episodes?token=deadbeef" ==
       URLRequest(
         data:
           try router
@@ -241,8 +233,8 @@ class URLRoutingTests: XCTestCase {
       )?.url?.absoluteString
     )
 
-    XCTAssertEqual(
-      "http://localhost:8080/v1/episodes?token=deadbeef",
+    #expect(
+      "http://localhost:8080/v1/episodes?token=deadbeef" ==
       URLRequest(
         data:
           try router


### PR DESCRIPTION
I've migrated the library to Swift Testing, as well as modernising some syntax to make things a bit clearer in some places, e.g. Raw Strings, `Data("Hello World".utf8)` instead of `"Hello World".data(using: .utf8)!` etc.

In some cases, I've switched the ordering of the expected/actual in `#expect` or `#require` blocks, as you can't have `try` on the right-hand side.

I also found the blessed way to migrate `XCTAssertThrowsError` is to capture the error using `try #require(throws:)` and then compare it, which is how I've migrated those specific error checks across.

I have *not* updated the tests to account for `@CasePathable` – adding an explicit dependency on CasePaths is something I'm looking at in a follow up, and some of the test routes are probably pretty good candidates for demonstrating how to migrate from the current syntax to the new `@CasePathable` equivalent!
Some will require renaming and reorganising too, as you can't apply extension macros like `@CasePathable` to function-local types.